### PR TITLE
Fix geometry parser

### DIFF
--- a/analyzer/data/geometry.py
+++ b/analyzer/data/geometry.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import dataclass
 from typing import List
 
+import numpy as np
 import pygeos
 
 log = logging.getLogger(__name__)
@@ -21,7 +22,7 @@ class Geometry:
     walkable_area: pygeos.Geometry
     obstacles: List[pygeos.Geometry]
 
-    def __init__(self, walkable_area: pygeos.Geometry, obstacles: pygeos.Geometry = None):
+    def __init__(self, walkable_area: pygeos.Geometry, obstacles: np.ndarray = None):
         self.obstacles = []
         self.walkable_area = walkable_area
 

--- a/analyzer/io/geometry_parser.py
+++ b/analyzer/io/geometry_parser.py
@@ -25,26 +25,51 @@ def parse_geometry(geometry_file: pathlib.Path) -> Geometry:
     """
     root = ET.parse(geometry_file).getroot()
     walls = _parse_geometry_walls(root)
+    obstacles = _parse_obstacles(root)
 
-    return Geometry(pygeos.polygonize(walls))
+    return Geometry(pygeos.polygonize(walls), obstacles)
 
 
 def _parse_geometry_walls(xml_root: ET.Element) -> np.ndarray:
-    """Parses the walls from the given xml node.
+    """Parses all walls from the given root of the geometry file.
 
     Args:
-        xml_root (ET.Element): root of the xml file
+        xml_root (ET.Element): root of the geometry file
 
     Returns:
-        list of all walls which are in the geometry
+        numpy array of all walls which are in the geometry
     """
     walls = []
-    for subroom in xml_root.iter("subroom"):
-        for polygon in subroom.iter("polygon"):
-            wall = []
-            for vertex in polygon.iter("vertex"):
-                x = float(vertex.attrib["px"])
-                y = float(vertex.attrib["py"])
-                wall.append([x, y])
-            walls.append(pygeos.linestrings(np.array(wall)))
+    for polygon_node in xml_root.findall("rooms/room/subroom/polygon"):
+        walls.append(_parse_vertex(polygon_node))
     return np.array(walls)
+
+
+def _parse_obstacles(xml_root: ET.Element) -> np.ndarray:
+    """Parses all obstacles from the given root of the geometry file.
+
+    Args:
+        xml_root (ET.Element): root of the geometry file
+
+    Returns:
+        numpy array of all obstacles (as polygons) which are in the geometry
+    """
+    obstacles = []
+    for obstacles_node in xml_root.findall("rooms/room/subroom/obstacle/polygon"):
+        obstacles.append(_parse_vertex(obstacles_node))
+    return pygeos.get_parts(pygeos.normalize(pygeos.polygonize(np.array(obstacles))))
+
+
+def _parse_vertex(polygon_node: ET.Element) -> pygeos.Geometry:
+    """Parses the given vertex as line string
+
+    Args:
+        polygon_node (ET.Element): xml node containing the vertex information
+
+    Returns:
+        linestring of the parsed vertex
+    """
+    border = []
+    for vertex in polygon_node.iter("vertex"):
+        border.append([float(vertex.attrib["px"]), float(vertex.attrib["py"])])
+    return pygeos.linestrings(np.array(border))


### PR DESCRIPTION
- use pygeos in geometry parser instead of shapely
- parse obstacles from geometry file

- [ ] use room/subroom ids to create room separately and then join them
- [ ] check with more complex geometries
- [ ] use in #69 when finished to parse geometry file instead of passing the geometries directly